### PR TITLE
chore: configure http port exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ The script will:
 2. Create a resource group and a two-instance VM Scale Set
 3. Run `setup_node.sh` on each VM to install Node.js and register a systemd service
 
+By default the script configures the load balancer to forward HTTP traffic with the `--backend-port 80` option in the `az vmss create` call. If you prefer to expose port 80 using a network security group rule instead, run:
+
+```bash
+NSG="${VMSS}-nsg"
+az network nsg rule create \
+  --resource-group "$RG" \
+  --nsg-name "$NSG" \
+  --name allow-http \
+  --priority 1000 \
+  --protocol Tcp \
+  --destination-port-ranges 80 \
+  --access Allow \
+  --direction Inbound
+```
+
 ## 2. Configure GitHub Actions
 Add the following secrets to your repository so the pipeline can deploy:
 

--- a/agent.cli
+++ b/agent.cli
@@ -28,7 +28,7 @@ az vmss create \
   --upgrade-policy-mode automatic \
   --public-ip-per-vm \
   --lb-sku Standard \
-  --ports 80
+  --backend-port 80
 
 # Run setup on all instances
 az vmss run-command invoke \


### PR DESCRIPTION
## Summary
- expose HTTP traffic via load balancer with `--backend-port 80`
- document load balancer and NSG options for port 80

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e6fd8f14833384f3e892e4dec19e