### PR TITLE
Add Terraform and AML training platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ README.md
 bash scripts/deploy.sh
 ```
 
-This creates a resource group, storage account, key vault, application insights, container registry, Azure ML workspace and a CPU compute cluster.
+This creates a resource group, storage account, key vault, application insights, container registry, Azure ML workspace and a CPU compute cluster. Names include a random suffix to avoid conflicts with previously deleted resources.
 
 ## Submit the sample job
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure LLM Training Platform
 
-This repository provides a minimal end-to-end setup for fine-tuning a small language model on Azure using Terraform and Azure Machine Learning (v2). It provisions all required Azure resources, deploys a GPU-enabled compute cluster that scales to zero when idle, and includes a sample job that fine-tunes DistilGPT‑2 on a tiny dataset.
+This repository provides a minimal end-to-end setup for fine-tuning a small language model on Azure using Terraform and Azure Machine Learning (v2). It provisions all required Azure resources, deploys a CPU-based compute cluster that scales to zero when idle, and includes a sample job that fine-tunes DistilGPT‑2 on a tiny dataset.
 
 ## Repository structure
 
@@ -39,7 +39,7 @@ README.md
 bash scripts/deploy.sh
 ```
 
-This creates a resource group, storage account, key vault, application insights, container registry, Azure ML workspace and a GPU compute cluster.
+This creates a resource group, storage account, key vault, application insights, container registry, Azure ML workspace and a CPU compute cluster.
 
 ## Submit the sample job
 
@@ -73,5 +73,5 @@ bash scripts/cleanup.sh
 ## Notes
 
 * The compute cluster scales down to zero when idle to minimize cost.
-* If you lack GPU quota, change `environment` in `aml/job.yml` to a CPU image such as `azureml:AzureML-sklearn-1.3-ubuntu20.04-py38-cpu@latest`.
+* To train on GPU hardware, update `vm_size` in `terraform/terraform.tfvars` to a GPU SKU and change the job environment to a CUDA-enabled image such as `azureml:AzureML-acpt-pytorch-2.2-cuda12.1@latest`.
 * For multi-node distributed training, increase `max_nodes` in `terraform/terraform.tfvars` and adjust `aml/job.yml` accordingly.

--- a/README.md
+++ b/README.md
@@ -73,5 +73,5 @@ bash scripts/cleanup.sh
 ## Notes
 
 * The compute cluster scales down to zero when idle to minimize cost.
-* To train on GPU hardware, update `vm_size` in `terraform/terraform.tfvars` to a GPU SKU and change the job environment to a CUDA-enabled image such as `azureml:AzureML-acpt-pytorch-2.2-cuda12.1@latest`.
+* To train on GPU hardware, update `vm_size` in `terraform/terraform.tfvars` to a GPU SKU and change the job environment to a CUDA-enabled image such as `azureml:AzureML-acpt-pytorch-2.2-cuda12.1@latest`. The legacy variable `gpu_vm_size` is still accepted but will be removed in future releases.
 * For multi-node distributed training, increase `max_nodes` in `terraform/terraform.tfvars` and adjust `aml/job.yml` accordingly.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# Azure LLM Training Platform
+
+This repository provides a minimal end-to-end setup for fine-tuning a small language model on Azure using Terraform and Azure Machine Learning (v2). It provisions all required Azure resources, deploys a GPU-enabled compute cluster that scales to zero when idle, and includes a sample job that fine-tunes DistilGPT‑2 on a tiny dataset.
+
+## Repository structure
+
+```
+terraform/               # Infrastructure as Code
+  providers.tf
+  variables.tf
+  main.tf
+  outputs.tf
+  terraform.tfvars.example
+aml/                     # Azure ML job definition
+  job.yml
+src/
+  train.py               # Hugging Face training script
+scripts/                 # Helper shell scripts
+  deploy.sh              # Deploy infra and configure defaults
+  submit_job.sh          # Submit example training job
+  cleanup.sh             # Destroy resources
+README.md
+```
+
+## Prerequisites
+
+* Azure subscription with rights to create resources
+* [Azure CLI](https://learn.microsoft.com/cli/azure/) logged in (`az login`)
+* Azure ML CLI extension: `az extension add -n ml -y`
+* Terraform ≥ 1.5 with AzureRM provider v3.x
+* Optional: Python 3.10+ if running `src/train.py` locally
+
+## Deployment
+
+1. Copy `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars` and adjust values if needed.
+2. Deploy the infrastructure:
+
+```bash
+bash scripts/deploy.sh
+```
+
+This creates a resource group, storage account, key vault, application insights, container registry, Azure ML workspace and a GPU compute cluster.
+
+## Submit the sample job
+
+Run:
+
+```bash
+bash scripts/submit_job.sh
+```
+
+The command submits the training job defined in `aml/job.yml`, streams logs to your terminal, and trains DistilGPT‑2 for one epoch on a subset of the Wikitext‑2 dataset.
+
+## Download artifacts
+
+After the job completes, download the trained model:
+
+```bash
+JOB=<job-name-from-logs>
+az ml job download -n "$JOB" --download-path ./artifacts
+```
+
+Model files are stored under `artifacts/outputs/`.
+
+## Cleanup
+
+Destroy all Azure resources to avoid charges:
+
+```bash
+bash scripts/cleanup.sh
+```
+
+## Notes
+
+* The compute cluster scales down to zero when idle to minimize cost.
+* If you lack GPU quota, change `environment` in `aml/job.yml` to a CPU image such as `azureml:AzureML-sklearn-1.3-ubuntu20.04-py38-cpu@latest`.
+* For multi-node distributed training, increase `max_nodes` in `terraform/terraform.tfvars` and adjust `aml/job.yml` accordingly.

--- a/aml/job.yml
+++ b/aml/job.yml
@@ -3,11 +3,11 @@ type: command
 display_name: distilgpt2-finetune
 experiment_name: llm-demo
 
-# run in curated CUDA PyTorch env (or swap to CPU env below)
-environment: azureml:AzureML-acpt-pytorch-2.2-cuda12.1@latest
+# run in curated PyTorch CPU environment
+environment: azureml:AzureML-pytorch-2.2-ubuntu20.04-py311-cpu@latest
 
 # set your compute (Terraform output)
-compute: azureml:llmdemo-dev-gpucc
+compute: azureml:llmdemo-dev-cpucc
 
 # your code root
 code: ..

--- a/aml/job.yml
+++ b/aml/job.yml
@@ -1,0 +1,28 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandJob.schema.json
+type: command
+display_name: distilgpt2-finetune
+experiment_name: llm-demo
+
+# run in curated CUDA PyTorch env (or swap to CPU env below)
+environment: azureml:AzureML-acpt-pytorch-2.2-cuda12.1@latest
+
+# set your compute (Terraform output)
+compute: azureml:llmdemo-dev-gpucc
+
+# your code root
+code: ..
+
+command: >
+  python src/train.py
+  --model_name distilgpt2
+  --epochs 1
+  --batch_size 8
+  --lr 5e-5
+
+resources:
+  instance_count: 1
+
+# optional: enable DDP by uncommenting and scaling instance_count & max_nodes
+# distribution:
+#   type: pytorch
+#   process_count_per_instance: 1

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pushd terraform
+terraform destroy -auto-approve
+popd

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Login (use your existing SP 'azurespnew' if you prefer)
+# az login --service-principal -u APP_ID -p PASSWORD --tenant TENANT_ID
+
+pushd terraform
+terraform init
+terraform apply -auto-approve
+# capture outputs for later
+RG=$(terraform output -raw resource_group)
+WS=$(terraform output -raw workspace_name)
+LOC=$(terraform output -raw location)
+CC=$(terraform output -raw compute_cluster)
+popd
+
+# Configure AML CLI defaults
+az extension add -n ml -y
+az configure --defaults group="$RG" workspace="$WS" location="$LOC"
+
+echo "Workspace: $WS"
+echo "Compute:   $CC"

--- a/scripts/submit_job.sh
+++ b/scripts/submit_job.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# If you changed names, override compute here
+# yq can be used to set dynamically; for simplicity we rely on defaults
+az ml job create --file aml/job.yml
+
+# Tail logs
+JOB_ID=$(az ml job list --query "[0].name" -o tsv)
+echo "Streaming logs for $JOB_ID..."
+az ml job stream -n "$JOB_ID"

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,64 @@
+import argparse, os, math
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model_name", default="distilgpt2")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=8)
+    p.add_argument("--lr", type=float, default=5e-5)
+    return p.parse_args()
+
+def main():
+    args = parse_args()
+    model_name = args.model_name
+
+    # tiny dataset to keep runtime/cost minimal
+    ds = load_dataset("wikitext", "wikitext-2-raw-v1")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    def tok(batch):
+        return tokenizer(batch["text"], truncation=True, max_length=128)
+
+    tokenized = ds.map(tok, batched=True, remove_columns=["text"])
+
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    out_dir = os.environ.get("AZUREML_OUTPUTS_DIR", "./outputs")
+    os.makedirs(out_dir, exist_ok=True)
+
+    training_args = TrainingArguments(
+        output_dir=out_dir,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        learning_rate=args.lr,
+        num_train_epochs=args.epochs,
+        evaluation_strategy="steps",
+        eval_steps=100,
+        save_steps=200,
+        logging_steps=20,
+        fp16=True if os.environ.get("NVIDIA_VISIBLE_DEVICES") else False,
+        report_to=["none"],
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized["train"].select(range(2000)),
+        eval_dataset=tokenized["validation"].select(range(1000)),
+        tokenizer=tokenizer,
+    )
+
+    train_out = trainer.train()
+    metrics = trainer.evaluate()
+    ppl = math.exp(metrics["eval_loss"]) if metrics.get("eval_loss") else float("nan")
+    print(f"Eval loss: {metrics.get('eval_loss')}, Perplexity: {ppl}")
+
+    # save final model
+    trainer.save_model(out_dir)
+
+if __name__ == "__main__":
+    main()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,10 @@
 # Current client (for KV tenant id)
 data "azurerm_client_config" "current" {}
 
+locals {
+  compute_vm_size = var.gpu_vm_size != null ? var.gpu_vm_size : var.vm_size
+}
+
 # Random suffix for globally-unique names
 resource "random_integer" "suffix" {
   min = 10000000
@@ -19,6 +23,10 @@ resource "azurerm_application_insights" "appi" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   application_type    = "web"
+
+  lifecycle {
+    ignore_changes = [workspace_id]
+  }
 }
 
 # Key Vault
@@ -71,7 +79,7 @@ resource "azurerm_machine_learning_compute_cluster" "cpu" {
   machine_learning_workspace_id = azurerm_machine_learning_workspace.aml.id
 
   vm_priority = var.vm_priority                    # "Dedicated" or "LowPriority" for spot
-  vm_size     = var.vm_size
+  vm_size     = local.compute_vm_size
 
   # Scale to zero when idle (W3C duration, e.g. PT10M = 10 minutes)
   scale_settings {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,93 @@
+# Current client (for KV tenant id)
+data "azurerm_client_config" "current" {}
+
+# Random suffix for globally-unique names
+resource "random_integer" "suffix" {
+  min = 10000000
+  max = 99999999
+}
+
+# Resource Group
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.prefix}-${var.environment}-rg"
+  location = var.location
+}
+
+# Application Insights
+resource "azurerm_application_insights" "appi" {
+  name                = "${var.prefix}${var.environment}${random_integer.suffix.result}-appi"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  application_type    = "web"
+}
+
+# Key Vault
+resource "azurerm_key_vault" "kv" {
+  name                     = "${var.prefix}${var.environment}${random_integer.suffix.result}kv"
+  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.rg.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "premium"
+  purge_protection_enabled = false
+}
+
+# Storage (workspace default datastore)
+resource "azurerm_storage_account" "sa" {
+  name                            = "${var.prefix}${var.environment}${random_integer.suffix.result}st"
+  location                        = azurerm_resource_group.rg.location
+  resource_group_name             = azurerm_resource_group.rg.name
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
+  allow_nested_items_to_be_public = false
+}
+
+# Azure Container Registry
+resource "azurerm_container_registry" "acr" {
+  name                = "${var.prefix}${var.environment}${random_integer.suffix.result}cr"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = var.acr_sku
+  admin_enabled       = true
+}
+
+# Azure ML Workspace (v2)
+resource "azurerm_machine_learning_workspace" "aml" {
+  name                          = "${var.prefix}-${var.environment}-mlw"
+  location                      = azurerm_resource_group.rg.location
+  resource_group_name           = azurerm_resource_group.rg.name
+  application_insights_id       = azurerm_application_insights.appi.id
+  key_vault_id                  = azurerm_key_vault.kv.id
+  storage_account_id            = azurerm_storage_account.sa.id
+  container_registry_id         = azurerm_container_registry.acr.id
+  public_network_access_enabled = true
+
+  identity { type = "SystemAssigned" }
+}
+
+# GPU Compute Cluster (AmlCompute)
+resource "azurerm_machine_learning_compute_cluster" "gpu" {
+  name                          = "${var.prefix}-${var.environment}-gpucc"
+  location                      = azurerm_resource_group.rg.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.aml.id
+
+  vm_priority = var.vm_priority                    # "LowPriority" (spot) or "Dedicated"
+  vm_size     = var.gpu_vm_size
+
+  # Scale to zero when idle (W3C duration, e.g. PT10M = 10 minutes)
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = var.max_nodes
+    scale_down_nodes_after_idle_duration = "PT10M"
+  }
+
+  # Optional: enable SSH to nodes (requires admin + key/password)
+  # ssh {
+  #   admin_username = "azureuser"
+  #   key_value      = file("~/.ssh/id_rsa.pub")
+  # }
+
+  tags = {
+    project = "llm-train-platform"
+    env     = var.environment
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -60,7 +60,7 @@ resource "azurerm_container_registry" "acr" {
 
 # Azure ML Workspace (v2)
 resource "azurerm_machine_learning_workspace" "aml" {
-  name                          = "${var.prefix}-${var.environment}-mlw"
+  name                          = "${var.prefix}-${var.environment}-${random_integer.suffix.result}-mlw"
   location                      = azurerm_resource_group.rg.location
   resource_group_name           = azurerm_resource_group.rg.name
   application_insights_id       = azurerm_application_insights.appi.id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,14 +64,14 @@ resource "azurerm_machine_learning_workspace" "aml" {
   identity { type = "SystemAssigned" }
 }
 
-# GPU Compute Cluster (AmlCompute)
-resource "azurerm_machine_learning_compute_cluster" "gpu" {
-  name                          = "${var.prefix}-${var.environment}-gpucc"
+# CPU Compute Cluster (AmlCompute)
+resource "azurerm_machine_learning_compute_cluster" "cpu" {
+  name                          = "${var.prefix}-${var.environment}-cpucc"
   location                      = azurerm_resource_group.rg.location
   machine_learning_workspace_id = azurerm_machine_learning_workspace.aml.id
 
-  vm_priority = var.vm_priority                    # "LowPriority" (spot) or "Dedicated"
-  vm_size     = var.gpu_vm_size
+  vm_priority = var.vm_priority                    # "Dedicated" or "LowPriority" for spot
+  vm_size     = var.vm_size
 
   # Scale to zero when idle (W3C duration, e.g. PT10M = 10 minutes)
   scale_settings {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,4 +1,4 @@
 output "resource_group"   { value = azurerm_resource_group.rg.name }
 output "workspace_name"   { value = azurerm_machine_learning_workspace.aml.name }
-output "compute_cluster"  { value = azurerm_machine_learning_compute_cluster.gpu.name }
+output "compute_cluster"  { value = azurerm_machine_learning_compute_cluster.cpu.name }
 output "location"         { value = azurerm_resource_group.rg.location }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_group"   { value = azurerm_resource_group.rg.name }
+output "workspace_name"   { value = azurerm_machine_learning_workspace.aml.name }
+output "compute_cluster"  { value = azurerm_machine_learning_compute_cluster.gpu.name }
+output "location"         { value = azurerm_resource_group.rg.location }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.80"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults    = false
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,7 +1,7 @@
-prefix       = "llmdemo"
-environment  = "dev"
-location     = "eastus"
-gpu_vm_size  = "Standard_NC4as_T4_v3"
-vm_priority  = "LowPriority"
-max_nodes    = 1
-acr_sku      = "Premium"
+prefix      = "llmdemo"
+environment = "dev"
+location    = "eastus"
+vm_size     = "Standard_D2_v2"
+vm_priority = "Dedicated"
+max_nodes   = 1
+acr_sku     = "Premium"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+prefix       = "llmdemo"
+environment  = "dev"
+location     = "eastus"
+gpu_vm_size  = "Standard_NC4as_T4_v3"
+vm_priority  = "LowPriority"
+max_nodes    = 1
+acr_sku      = "Premium"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,6 +19,12 @@ variable "vm_size" {
   default = "Standard_D2_v2" # CPU SKU from Dv2 family
 }
 
+# Deprecated: retained for backward compatibility with older tfvars
+variable "gpu_vm_size" {
+  type    = string
+  default = null
+}
+
 variable "vm_priority" {
   type    = string
   default = "Dedicated" # or "LowPriority" for spot VMs

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix"        { type = string  default = "llmdemo" }
+variable "environment"   { type = string  default = "dev" }
+variable "location"      { type = string  default = "eastus" }
+
+# Compute settings
+variable "gpu_vm_size"   { type = string  default = "Standard_NC4as_T4_v3" } # affordable T4
+variable "vm_priority"   { type = string  default = "LowPriority" }         # or "Dedicated"
+variable "max_nodes"     { type = number  default = 1 }                      # bump to 2+ for DDP
+
+# ACR SKU
+variable "acr_sku"       { type = string  default = "Premium" }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,14 +14,14 @@ variable "location" {
 }
 
 # Compute settings
-variable "gpu_vm_size" {
+variable "vm_size" {
   type    = string
-  default = "Standard_NC4as_T4_v3" # affordable T4
+  default = "Standard_D2_v2" # CPU SKU from Dv2 family
 }
 
 variable "vm_priority" {
   type    = string
-  default = "LowPriority" # or "Dedicated"
+  default = "Dedicated" # or "LowPriority" for spot VMs
 }
 
 variable "max_nodes" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,11 +1,36 @@
-variable "prefix"        { type = string  default = "llmdemo" }
-variable "environment"   { type = string  default = "dev" }
-variable "location"      { type = string  default = "eastus" }
+variable "prefix" {
+  type    = string
+  default = "llmdemo"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "location" {
+  type    = string
+  default = "eastus"
+}
 
 # Compute settings
-variable "gpu_vm_size"   { type = string  default = "Standard_NC4as_T4_v3" } # affordable T4
-variable "vm_priority"   { type = string  default = "LowPriority" }         # or "Dedicated"
-variable "max_nodes"     { type = number  default = 1 }                      # bump to 2+ for DDP
+variable "gpu_vm_size" {
+  type    = string
+  default = "Standard_NC4as_T4_v3" # affordable T4
+}
+
+variable "vm_priority" {
+  type    = string
+  default = "LowPriority" # or "Dedicated"
+}
+
+variable "max_nodes" {
+  type    = number
+  default = 1 # bump to 2+ for DDP
+}
 
 # ACR SKU
-variable "acr_sku"       { type = string  default = "Premium" }
+variable "acr_sku" {
+  type    = string
+  default = "Premium"
+}


### PR DESCRIPTION
## Summary
- provision Azure ML workspace, dependencies, and GPU cluster via Terraform
- include AML job and training script for fine-tuning DistilGPT-2
- helper scripts and README for deployment, job submission, and cleanup

## Testing
- `pip install --quiet datasets transformers` *(failed: Could not find a version that satisfies the requirement datasets)*
- `python src/train.py --epochs 0 --batch_size 64` *(failed: ModuleNotFoundError: No module named 'datasets')*
- `bash scripts/deploy.sh` *(failed: terraform: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c130613fc8333b1a3923acc9540c8