### PR TITLE
Add CPU-based Azure ML fine-tuning scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules/
-.DS_Store
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Azure LLM Training Platform (CPU)
+
+This project provisions an Azure Machine Learning (AML) workspace and a CPU compute cluster, then runs a sample job that fine‑tunes [DistilGPT‑2](https://huggingface.co/distilgpt2) on the tiny Wikitext‑2 dataset. Infrastructure is managed with Terraform and jobs are submitted with the Azure ML CLI (v2).
+
+## Repository Layout
+```
+terraform/               # Terraform IaC for AML workspace & compute
+aml/job.yml              # Sample AML command job definition
+src/train.py             # Hugging Face training script
+scripts/deploy.sh        # Provision infra and configure CLI defaults
+scripts/submit_job.sh    # Submit the example training job
+scripts/cleanup.sh       # Destroy all provisioned resources
+```
+
+## Prerequisites
+* Azure subscription with permissions to create resources
+* [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (`az`) and logged in
+* ML extension: `az extension add -n ml -y`
+* [Terraform](https://www.terraform.io/downloads.html) ≥ 1.5
+* Optional: Python 3.10+ if you want to run `src/train.py` locally for testing
+
+## Deploy Infrastructure
+```
+bash scripts/deploy.sh
+```
+This initializes Terraform and creates the resource group, supporting services (Storage, Key Vault, App Insights, ACR), AML workspace and a **CPU** compute cluster (`Standard_D2_v2`) that scales to zero when idle. The script configures the Azure ML CLI defaults using the created workspace.
+
+## Run the Sample Training Job
+```
+bash scripts/submit_job.sh
+```
+The job uses the curated environment `AzureML-pytorch-2.2-ubuntu20.04-py310-cpu@latest` and runs the training script on the CPU cluster. Logs are streamed automatically. After the job completes, the model artifacts can be downloaded with:
+```
+JOB=<job-name-from-logs>
+az ml job download -n "$JOB" --download-path ./artifacts
+```
+
+## Cleanup
+Destroy all deployed resources when done:
+```
+bash scripts/cleanup.sh
+```
+
+## Notes
+* Change values in `terraform/terraform.tfvars` (copy from the `.example` file) to customize naming or region.
+* To experiment with multiple nodes, increase `max_nodes` in the tfvars file and set `instance_count` and `distribution` in `aml/job.yml` accordingly.
+* For production scenarios, consider using private networking and managed identities.

--- a/aml/job.yml
+++ b/aml/job.yml
@@ -1,0 +1,20 @@
+$schema: https://azuremlschemas.azureedge.net/latest/commandJob.schema.json
+type: command
+display_name: distilgpt2-finetune
+experiment_name: llm-demo
+
+environment: azureml:AzureML-pytorch-2.2-ubuntu20.04-py310-cpu@latest
+
+compute: azureml:llmdemo-dev-cpucc
+
+code: ..
+
+command: >
+  python src/train.py \
+  --model_name distilgpt2 \
+  --epochs 1 \
+  --batch_size 8 \
+  --lr 5e-5
+
+resources:
+  instance_count: 1

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pushd terraform
+terraform destroy -auto-approve
+popd

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Login (use your existing SP 'azurespnew' if you prefer)
+# az login --service-principal -u APP_ID -p PASSWORD --tenant TENANT_ID
+
+pushd terraform
+terraform init
+terraform apply -auto-approve
+# capture outputs for later
+RG=$(terraform output -raw resource_group)
+WS=$(terraform output -raw workspace_name)
+LOC=$(terraform output -raw location)
+CC=$(terraform output -raw compute_cluster)
+popd
+
+# Configure AML CLI defaults
+az extension add -n ml -y
+az configure --defaults group="$RG" workspace="$WS" location="$LOC"
+
+echo "Workspace: $WS"
+echo "Compute:   $CC"

--- a/scripts/submit_job.sh
+++ b/scripts/submit_job.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# If you changed names, override compute here
+# yq can be used to set dynamically; for simplicity we rely on defaults
+az ml job create --file aml/job.yml
+
+# Tail logs
+JOB_ID=$(az ml job list --query "[0].name" -o tsv)
+echo "Streaming logs for $JOB_ID..."
+az ml job stream -n "$JOB_ID"

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,67 @@
+import argparse, os, math
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM, Trainer, TrainingArguments
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--model_name", default="distilgpt2")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=8)
+    p.add_argument("--lr", type=float, default=5e-5)
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    model_name = args.model_name
+
+    # tiny dataset to keep runtime/cost minimal
+    ds = load_dataset("wikitext", "wikitext-2-raw-v1")
+    tokenizer = AutoTokenizer.from_pretrained(model_name, use_fast=True)
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    def tok(batch):
+        return tokenizer(batch["text"], truncation=True, max_length=128)
+
+    tokenized = ds.map(tok, batched=True, remove_columns=["text"])
+
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    out_dir = os.environ.get("AZUREML_OUTPUTS_DIR", "./outputs")
+    os.makedirs(out_dir, exist_ok=True)
+
+    training_args = TrainingArguments(
+        output_dir=out_dir,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        learning_rate=args.lr,
+        num_train_epochs=args.epochs,
+        evaluation_strategy="steps",
+        eval_steps=100,
+        save_steps=200,
+        logging_steps=20,
+        fp16=True if os.environ.get("NVIDIA_VISIBLE_DEVICES") else False,
+        report_to=["none"],
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized["train"].select(range(2000)),
+        eval_dataset=tokenized["validation"].select(range(1000)),
+        tokenizer=tokenizer,
+    )
+
+    train_out = trainer.train()
+    metrics = trainer.evaluate()
+    ppl = math.exp(metrics["eval_loss"]) if metrics.get("eval_loss") else float("nan")
+    print(f"Eval loss: {metrics.get('eval_loss')}, Perplexity: {ppl}")
+
+    # save final model
+    trainer.save_model(out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,86 @@
+# Current client (for KV tenant id)
+data "azurerm_client_config" "current" {}
+
+# Random suffix for globally-unique names
+resource "random_integer" "suffix" {
+  min = 10000000
+  max = 99999999
+}
+
+# Resource Group
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.prefix}-${var.environment}-rg"
+  location = var.location
+}
+
+# Application Insights
+resource "azurerm_application_insights" "appi" {
+  name                = "${var.prefix}${var.environment}${random_integer.suffix.result}-appi"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  application_type    = "web"
+}
+
+# Key Vault
+resource "azurerm_key_vault" "kv" {
+  name                     = "${var.prefix}${var.environment}${random_integer.suffix.result}kv"
+  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.rg.name
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  sku_name                 = "premium"
+  purge_protection_enabled = false
+}
+
+# Storage (workspace default datastore)
+resource "azurerm_storage_account" "sa" {
+  name                            = "${var.prefix}${var.environment}${random_integer.suffix.result}st"
+  location                        = azurerm_resource_group.rg.location
+  resource_group_name             = azurerm_resource_group.rg.name
+  account_tier                    = "Standard"
+  account_replication_type        = "GRS"
+  allow_nested_items_to_be_public = false
+}
+
+# Azure Container Registry
+resource "azurerm_container_registry" "acr" {
+  name                = "${var.prefix}${var.environment}${random_integer.suffix.result}cr"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = var.acr_sku
+  admin_enabled       = true
+}
+
+# Azure ML Workspace (v2)
+resource "azurerm_machine_learning_workspace" "aml" {
+  name                          = "${var.prefix}-${var.environment}-mlw"
+  location                      = azurerm_resource_group.rg.location
+  resource_group_name           = azurerm_resource_group.rg.name
+  application_insights_id       = azurerm_application_insights.appi.id
+  key_vault_id                  = azurerm_key_vault.kv.id
+  storage_account_id            = azurerm_storage_account.sa.id
+  container_registry_id         = azurerm_container_registry.acr.id
+  public_network_access_enabled = true
+
+  identity { type = "SystemAssigned" }
+}
+
+# CPU Compute Cluster (AmlCompute)
+resource "azurerm_machine_learning_compute_cluster" "cpu" {
+  name                          = "${var.prefix}-${var.environment}-cpucc"
+  location                      = azurerm_resource_group.rg.location
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.aml.id
+
+  vm_priority = var.vm_priority
+  vm_size     = var.vm_size
+
+  scale_settings {
+    min_node_count                       = 0
+    max_node_count                       = var.max_nodes
+    scale_down_nodes_after_idle_duration = "PT10M"
+  }
+
+  tags = {
+    project = "llm-train-platform"
+    env     = var.environment
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "resource_group"  { value = azurerm_resource_group.rg.name }
+output "workspace_name"  { value = azurerm_machine_learning_workspace.aml.name }
+output "compute_cluster" { value = azurerm_machine_learning_compute_cluster.cpu.name }
+output "location"        { value = azurerm_resource_group.rg.location }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.80"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults    = false
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+prefix      = "llmdemo"
+environment = "dev"
+location    = "eastus"
+vm_size     = "Standard_D2_v2"
+vm_priority = "Dedicated"
+max_nodes   = 1
+acr_sku     = "Premium"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "prefix"      { type = string  default = "llmdemo" }
+variable "environment" { type = string  default = "dev" }
+variable "location"    { type = string  default = "eastus" }
+
+# Compute settings
+variable "vm_size"     { type = string  default = "Standard_D2_v2" } # CPU SKU
+variable "vm_priority" { type = string  default = "Dedicated" }     # or "LowPriority"
+variable "max_nodes"   { type = number  default = 1 }
+
+# ACR SKU
+variable "acr_sku"     { type = string  default = "Premium" }


### PR DESCRIPTION
## Summary
- provision Azure ML workspace, dependencies, and CPU compute with Terraform
- define command job and training script to fine-tune DistilGPT-2
- helper scripts and README for deployment, job submission, and cleanup

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `bash -n scripts/deploy.sh`
- `bash -n scripts/submit_job.sh`
- `bash -n scripts/cleanup.sh`
- `python -m py_compile src/train.py`


------
https://chatgpt.com/codex/tasks/task_e_689c544ecc40833396ed8d9213d765cb