### PR TITLE
Add AKS observability reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,146 @@
+# AKS Observability Reference
+
+This project provides an end-to-end observability stack for Azure Kubernetes Service (AKS) using **Managed Prometheus**, **Container Insights** (Azure Monitor Agent + Data Collection Rule), **Log Analytics**, and **Azure Managed Grafana**.
+
+## Architecture
+
+```
++----------------------+         +---------------------------+
+| Azure Managed        |<------->| Azure Monitor Workspace   |<- PromQL
+| Grafana (Managed MI) |   RBAC  | (Prometheus data store)   |
++----------+-----------+         +------------+--------------+
+           ^                                     ^
+           |                                     |
+           | Azure Auth (Monitoring Data Reader) |
+           |                                     | DCE/DCR (MSPROM-*)
+           |                                     |
++----------+-------------------+     +-----------+------------------+
+| AKS Cluster (Managed ID)    |----->| Managed Prometheus Addon     |
+|  - Workloads (/metrics)     |      |  (ama-metrics RS/DS)         |
+|  - pod annotations          |      +------------------------------+
+|                             |
+|  AMA (azuremonitor-containers) -> DCR (MSCI-*) -> Log Analytics   |
++-----------------------------+                                     |
+                                                                      v
+                                                          Log Analytics (KQL)
+```
+
+Enabling Managed Prometheus and Container Insights creates **MSPROM-\*** and **MSCI-\*** Data Collection Rules and installs the required agents.
+
+## Repository Layout
+
+```
+/infra   Terraform configuration for core resources (RG, AMW, LAW, AKS, Grafana)
+/alerts  Terraform modules for Prometheus rule groups and log alerts
+/k8s     Kubernetes manifests for demo apps and custom scrape configs
+grafana/dashboards  Example SLO dashboard JSON
+```
+
+## Prerequisites
+
+- Azure subscription with the following providers registered: `Microsoft.ContainerService`, `Microsoft.Monitor`, `Microsoft.AlertsManagement`, `Microsoft.Insights`, `Microsoft.Dashboard`.
+- An AKS cluster using managed identity.
+- Chosen region that satisfies Azure Monitor workspace and AKS region pairing rules.
+- [Terraform 1.6+](https://developer.hashicorp.com/terraform/downloads) and the Azure CLI installed locally.
+
+## Deploy Core Platform with Terraform
+
+```bash
+cd infra
+terraform init
+terraform apply \
+  -var 'rg_name=rg-aks-o11y' \
+  -var 'location=eastus' \
+  -var 'name=aks-o11y'
+```
+
+This creates:
+
+- Resource group
+- Azure Monitor workspace (Prometheus)
+- Log Analytics workspace
+- Managed Grafana instance and RBAC
+- AKS cluster with Managed Prometheus enabled
+- Container Insights (AMA) extension
+
+### Enabling Managed Prometheus on an Existing Cluster
+
+```bash
+az aks update -g <rg> -n <cluster> \
+  --enable-azure-monitor-metrics \
+  --azure-monitor-workspace-resource-id <amw-id> \
+  --ksm-metric-labels-allow-list "namespaces=[kubernetes_io_metadata_name]" \
+  --ksm-metric-annotations-allow-list "pods=[prometheus.io/scrape,prometheus.io/port,prometheus.io/path]"
+```
+
+## Deploy Demo Application and Optional Scrape Config
+
+```bash
+kubectl apply -f k8s/demo-app.yaml
+# Optional custom scrape configuration
+kubectl apply -f k8s/ama-metrics-prometheus-config.yaml
+```
+
+## Grafana
+
+1. Open the Managed Grafana endpoint (output from Terraform).
+2. Add a Prometheus data source pointing to the Azure Monitor workspace query endpoint and choose **Azure Auth**.
+3. Import the dashboard JSON in `grafana/dashboards/slo-api.json` to visualize SLO metrics.
+
+## Alerting
+
+After the core platform is deployed, create alert rules:
+
+```bash
+cd alerts
+terraform init
+terraform apply \
+  -var 'name=aks-o11y' \
+  -var 'location=eastus' \
+  -var 'resource_group_name=rg-aks-o11y' \
+  -var 'monitor_workspace_id=<amw-id>' \
+  -var 'log_analytics_workspace_id=<law-id>' \
+  -var 'action_group_id=<action-group-id>'
+```
+
+- `prom-rule-group.tf` provisions Prometheus alert and recording rules.
+- `log-alerts.tf` sets up log-based alerts (e.g., CrashLoopBackOff) using KQL queries.
+
+## Cost and Data-Volume Guardrails
+
+- Managed Prometheus defaults to minimal ingestion; expand only as needed.
+- Container Insights uses `ContainerLogV2` schema; apply Basic table plan where appropriate.
+- Tune log collection through the MSCI data collection rule.
+
+## Validation & Troubleshooting
+
+```bash
+# Confirm Managed Prometheus enabled
+az aks show -g <rg> -n <cluster> --query "azureMonitorProfile" -o yaml
+
+# Check metrics pods
+kubectl get pods -n kube-system | grep ama-metrics
+
+# View scrape targets
+kubectl logs -n kube-system deploy/ama-metrics | head -n 100
+```
+
+If logs are missing, ensure the `azuremonitor-containers` extension is installed and that the `ContainerLogV2` tables are ingested in Log Analytics.
+
+## Example SLO Policy
+
+- **Availability:** ≥ 99.9% monthly (`1 - 5xx_rate / total_rate`)
+- **Latency:** 95th percentile ≤ 300 ms over 30 days
+- **Saturation:** Node CPU < 80% sustained
+
+Multi-window, multi-burn alerts can be configured using additional rules in the Prometheus rule group.
+
+## How to Run the Project
+
+1. Deploy infrastructure with Terraform (`/infra`).
+2. Enable Managed Prometheus on existing clusters if needed.
+3. Deploy Kubernetes manifests (`/k8s`).
+4. Configure Grafana and import dashboards (`/grafana`).
+5. Provision alert rules (`/alerts`).
+6. Validate metrics and logs using the runbook above.
+

--- a/alerts/log-alerts.tf
+++ b/alerts/log-alerts.tf
@@ -1,0 +1,50 @@
+variable "name" {
+  description = "Base name for alert resources"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group containing the Log Analytics workspace"
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "ID of the Log Analytics workspace"
+  type        = string
+}
+
+variable "action_group_id" {
+  description = "ID of the action group for alert notifications"
+  type        = string
+}
+
+resource "azurerm_monitor_scheduled_query_rules_log" "pod_crashloop" {
+  name                = "${var.name}-pod-crashloop"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+
+  data_source_id = var.log_analytics_workspace_id
+  description    = "Pods in CrashLoopBackOff"
+  enabled        = true
+  time_window_minutes         = 10
+  evaluation_frequency_minutes = 5
+  query = <<KQL
+KubePodInventory
+| where ContainerStatus contains "CrashLoopBackOff"
+| summarize cnt = count() by ClusterName, Namespace, PodName, bin(TimeGenerated, 5m)
+KQL
+
+  trigger {
+    operator  = "GreaterThan"
+    threshold = 0
+  }
+
+  action {
+    action_group = [var.action_group_id]
+  }
+}

--- a/alerts/prom-rule-group.tf
+++ b/alerts/prom-rule-group.tf
@@ -1,0 +1,58 @@
+variable "name" {
+  description = "Base name for alert resources"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group containing the Azure Monitor workspace"
+  type        = string
+}
+
+variable "monitor_workspace_id" {
+  description = "ID of the Azure Monitor workspace"
+  type        = string
+}
+
+variable "action_group_id" {
+  description = "ID of the action group for alert notifications"
+  type        = string
+}
+
+resource "azurerm_monitor_alert_prometheus_rule_group" "app_slo" {
+  name                = "${var.name}-prom-slo"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  scopes              = [var.monitor_workspace_id]
+  interval            = "PT1M"
+  enabled             = true
+
+  rule {
+    alert  = "High5xxRate"
+    expr   = "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) > 0.005"
+    for    = "PT5M"
+    labels = {
+      severity = "2"
+      team     = "platform"
+    }
+    annotations = {
+      summary     = "5xx error rate > 0.5% for 5m"
+      description = "Check recent deployments or upstream dependencies."
+    }
+    action {
+      action_group_id = var.action_group_id
+    }
+  }
+
+  rule {
+    alert = "LatencyP95High"
+    expr  = "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket[5m]))) > 0.3"
+    for   = "PT10M"
+    labels = { severity = "2" }
+    annotations = { summary = "p95 > 300ms" }
+  }
+}

--- a/grafana/dashboards/slo-api.json
+++ b/grafana/dashboards/slo-api.json
@@ -1,0 +1,38 @@
+{
+  "title": "API SLO Dashboard",
+  "uid": "slo-api",
+  "schemaVersion": 38,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Availability",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "1 - ( sum(rate(http_requests_total{job=\"apps-annotated\", status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"apps-annotated\"}[5m])) )"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency p95",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"apps-annotated\"}[5m])))"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Node CPU Saturation",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg_over_time(node_cpu_seconds_total{mode!=\"idle\"}[5m]) / count_without(mode)(node_cpu_seconds_total)"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,74 @@
+resource "azurerm_resource_group" "o11y" {
+  name     = var.rg_name
+  location = var.location
+}
+
+# Azure Monitor workspace (Prometheus data store)
+resource "azurerm_monitor_workspace" "amw" {
+  name                          = "${var.name}-amw"
+  location                      = azurerm_resource_group.o11y.location
+  resource_group_name           = azurerm_resource_group.o11y.name
+  public_network_access_enabled = true
+  tags                          = var.tags
+}
+
+# Log Analytics workspace for Container Insights
+resource "azurerm_log_analytics_workspace" "law" {
+  name                = "${var.name}-law"
+  location            = azurerm_resource_group.o11y.location
+  resource_group_name = azurerm_resource_group.o11y.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = var.tags
+}
+
+# Managed Grafana
+resource "azurerm_dashboard_grafana" "mg" {
+  name                = "${var.name}-mgraf"
+  location            = azurerm_resource_group.o11y.location
+  resource_group_name = azurerm_resource_group.o11y.name
+  zone_redundancy_enabled = false
+  identity {
+    type = "SystemAssigned"
+  }
+  tags = var.tags
+}
+
+# Allow Grafana to read Prometheus in the AM workspace
+resource "azurerm_role_assignment" "mg_to_amw_reader" {
+  scope                = azurerm_monitor_workspace.amw.id
+  role_definition_name = "Monitoring Data Reader"
+  principal_id         = azurerm_dashboard_grafana.mg.identity[0].principal_id
+}
+
+# Create an AKS cluster with Managed Prometheus enabled
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = "${var.name}-aks"
+  location            = azurerm_resource_group.o11y.location
+  resource_group_name = azurerm_resource_group.o11y.name
+  dns_prefix          = "${var.name}-dns"
+
+  default_node_pool {
+    name       = "system"
+    vm_size    = "Standard_D4ds_v5"
+    node_count = 3
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  # Enable Azure Monitor managed service for Prometheus
+  monitor_metrics {
+    labels_allowed      = "namespaces=[kubernetes_io_metadata_name]"
+    annotations_allowed = "pods=[prometheus.io/scrape,prometheus.io/port,prometheus.io/path]"
+  }
+}
+
+# Container Insights using Azure Monitor Agent
+resource "azurerm_kubernetes_cluster_extension" "ci" {
+  name           = "azuremonitor-containers"
+  cluster_id     = azurerm_kubernetes_cluster.aks.id
+  extension_type = "azuremonitor-containers"
+  release_train  = "Stable"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,19 @@
+output "monitor_workspace_id" {
+  description = "ID of the Azure Monitor workspace"
+  value       = azurerm_monitor_workspace.amw.id
+}
+
+output "log_analytics_workspace_id" {
+  description = "ID of the Log Analytics workspace"
+  value       = azurerm_log_analytics_workspace.law.id
+}
+
+output "grafana_endpoint" {
+  description = "URL of the managed Grafana instance"
+  value       = azurerm_dashboard_grafana.mg.endpoint
+}
+
+output "aks_cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.aks.name
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.3.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+provider "azapi" {}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,20 @@
+variable "rg_name" {
+  description = "Name of the resource group for observability resources"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where resources will be created"
+  type        = string
+}
+
+variable "name" {
+  description = "Base name used for naming resources"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/k8s/ama-metrics-prometheus-config.yaml
+++ b/k8s/ama-metrics-prometheus-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ama-metrics-prometheus-config
+  namespace: kube-system
+data:
+  prometheus-config: |
+    global:
+      scrape_interval: 30s
+    scrape_configs:
+    - job_name: 'apps-annotated'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        regex: "true"
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        target_label: __metrics_path__
+        regex: "(.+)"
+      - action: replace
+        source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_port]
+        target_label: __address__
+        regex: "(.+)"

--- a/k8s/demo-app.yaml
+++ b/k8s/demo-app.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+  labels:
+    app: hello
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: hello
+          image: ghcr.io/prometheuscommunity/hello:latest
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  selector:
+    app: hello
+  ports:
+    - port: 80
+      targetPort: 8080


### PR DESCRIPTION
## Summary
- provide Terraform to deploy Azure Monitor workspace, Log Analytics, Managed Grafana and AKS with Managed Prometheus
- add Kubernetes demo app and optional Prometheus scrape configuration
- include alerting modules and sample SLO dashboard, plus project README

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*
- `cd infra && terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c63c5b1d483338218b90829106218