### PR TITLE
Add AKS observability sample with Azure Monitor and Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# AKS Observability Stack
+
+This project deploys an **Azure Kubernetes Service (AKS)** cluster with:
+
+- **Container Insights** for basic metrics and logs.
+- **Azure Monitor managed service for Prometheus** for scrape-based metrics and alerting.
+- **Azure Managed Grafana** for dashboards.
+- A sample application exposing Prometheus metrics, SLO dashboard, and alert rules.
+
+## Prerequisites
+
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) with the `aks-preview` and `amg` extensions.
+- Logged in to Azure: `az login`
+- A subscription where you have permission to create resources.
+
+## Deployment
+
+```bash
+# Make script executable
+chmod +x infra/deploy-aks-monitoring.sh
+
+# Run the deployment script
+./infra/deploy-aks-monitoring.sh
+```
+
+The script performs the following steps:
+
+1. Creates a resource group and Log Analytics workspace.
+2. Provisions an AKS cluster with Container Insights and managed Prometheus enabled.
+3. Deploys a sample application that exposes Prometheus metrics.
+4. Applies a Prometheus `PrometheusRule` for a simple SLO alert (error rate > 1%).
+5. Creates a Managed Grafana instance and grants the current user admin access.
+
+## SLO Dashboard
+
+Import `grafana/slo-dashboard.json` into the Managed Grafana instance to visualize the request success rate for the sample application.
+
+## Alerting
+
+The `alerts/pod-availability-rule.yaml` file defines a basic alerting rule that triggers when more than 1% of requests fail for 5 minutes. In a real environment you can configure alert routing to email, Teams, etc., using Azure Monitor alerting.
+
+## Cleanup
+
+Remove all deployed resources when you are done:
+
+```bash
+az group delete --name aks-observability-rg --yes --no-wait
+```
+
+## Notes
+
+This repository provides reference scripts and manifests. Review and adjust variables in `infra/deploy-aks-monitoring.sh` to fit your environment.

--- a/alerts/pod-availability-rule.yaml
+++ b/alerts/pod-availability-rule.yaml
@@ -1,0 +1,18 @@
+# PrometheusRule for Azure Monitor managed service for Prometheus
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pod-availability
+  namespace: default
+spec:
+  groups:
+    - name: pod-availability
+      rules:
+        - alert: HighErrorRate
+          expr: 1 - (sum(rate(http_requests_total{job="prometheus-example-app",status!~"5.."}[5m])) / sum(rate(http_requests_total{job="prometheus-example-app"}[5m]))) > 0.01
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Request error rate >1%"
+            description: "More than 1% of requests to prometheus-example-app failed in the last 5 minutes."

--- a/grafana/slo-dashboard.json
+++ b/grafana/slo-dashboard.json
@@ -1,0 +1,25 @@
+{
+  "uid": "slo-dashboard",
+  "title": "AKS Sample SLO",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Request Success Rate",
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{job=\"prometheus-example-app\",status!~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"prometheus-example-app\"}[5m]))",
+          "legendFormat": "success rate"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent"
+        }
+      }
+    }
+  ]
+}

--- a/infra/deploy-aks-monitoring.sh
+++ b/infra/deploy-aks-monitoring.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Script to provision an AKS cluster with Azure Monitor, Managed Prometheus and Managed Grafana.
+# It creates the required resources and deploys a sample application and alerting rules.
+# Prerequisites: Azure CLI with the 'aks-preview' and 'amg' extensions, logged in with sufficient permissions.
+
+set -euo pipefail
+
+# ---------- Configuration ----------
+RESOURCE_GROUP="aks-observability-rg"
+LOCATION="eastus"
+AKS_NAME="aks-observability"
+LOG_ANALYTICS_WS="aks-la"
+GRAFANA_NAME="aks-grafana"
+
+# ---------- Resource group ----------
+echo "Creating resource group $RESOURCE_GROUP in $LOCATION"
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+# ---------- Log Analytics ----------
+echo "Creating Log Analytics workspace"
+az monitor log-analytics workspace create \
+  --resource-group "$RESOURCE_GROUP" \
+  --workspace-name "$LOG_ANALYTICS_WS"
+
+WORKSPACE_ID=$(az monitor log-analytics workspace show -g "$RESOURCE_GROUP" -n "$LOG_ANALYTICS_WS" --query id -o tsv)
+
+# ---------- AKS cluster ----------
+echo "Creating AKS cluster with Container Insights and Azure Monitor managed Prometheus"
+az aks create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AKS_NAME" \
+  --location "$LOCATION" \
+  --enable-addons monitoring \
+  --enable-azure-monitor-metrics \
+  --workspace-resource-id "$WORKSPACE_ID" \
+  --node-count 2 \
+  --generate-ssh-keys
+
+# Get cluster credentials for kubectl
+az aks get-credentials -g "$RESOURCE_GROUP" -n "$AKS_NAME"
+
+# ---------- Sample workload ----------
+echo "Deploying sample application with Prometheus metrics"
+kubectl apply -f k8s/sample-app.yaml
+
+# ---------- Alert rules ----------
+echo "Applying Prometheus alerting rules"
+kubectl apply -f alerts/pod-availability-rule.yaml
+
+# ---------- Managed Grafana ----------
+echo "Creating Managed Grafana instance"
+az grafana create \
+  --name "$GRAFANA_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku Standard
+
+# Assign current user access to Grafana instance
+USER_ID=$(az ad signed-in-user show --query objectId -o tsv)
+az role assignment create --assignee "$USER_ID" --role "Grafana Admin" --scope $(az grafana show -g "$RESOURCE_GROUP" -n "$GRAFANA_NAME" --query id -o tsv)
+
+echo "Grafana instance created. Import grafana/slo-dashboard.json to visualize SLOs."
+
+echo "Deployment complete."

--- a/k8s/sample-app.yaml
+++ b/k8s/sample-app.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-example-app
+  labels:
+    app: prometheus-example-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-example-app
+  template:
+    metadata:
+      labels:
+        app: prometheus-example-app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+        - name: prometheus-example-app
+          image: quay.io/brancz/prometheus-example-app:v0.3.0
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-example-app
+spec:
+  selector:
+    app: prometheus-example-app
+  ports:
+    - port: 80
+      targetPort: 8080


### PR DESCRIPTION
## Summary
- provision AKS with Container Insights, managed Prometheus, and Managed Grafana via az CLI script
- sample workload exposing Prometheus metrics and alert rule
- Grafana dashboard and setup instructions in README

## Testing
- `bash -n infra/deploy-aks-monitoring.sh`
- `jq . grafana/slo-dashboard.json`
- `python - <<'PY' ...` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_689c862d5c388333a8b0d5c87681ba90